### PR TITLE
lspserver: document sync framework

### DIFF
--- a/lib/lspserver/include/lspserver/DraftStore.h
+++ b/lib/lspserver/include/lspserver/DraftStore.h
@@ -1,0 +1,59 @@
+//===--- DraftStore.h - File contents container -----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "Path.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/Support/VirtualFileSystem.h"
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace lspserver {
+
+/// A thread-safe container for files opened in a workspace, addressed by
+/// filenames. The contents are owned by the DraftStore.
+/// Each time a draft is updated, it is assigned a version. This can be
+/// specified by the caller or incremented from the previous version.
+class DraftStore {
+public:
+  struct Draft {
+    std::shared_ptr<const std::string> Contents;
+    std::string Version;
+  };
+
+  /// \return Contents of the stored document.
+  /// For untracked files, a std::nullopt is returned.
+  std::optional<Draft> getDraft(PathRef File) const;
+
+  /// \return List of names of the drafts in this store.
+  std::vector<Path> getActiveFiles() const;
+
+  /// Replace contents of the draft for \p File with \p Contents.
+  /// If version is empty, one will be automatically assigned.
+  /// Returns the version.
+  std::string addDraft(PathRef File, llvm::StringRef Version,
+                       llvm::StringRef Contents);
+
+  /// Remove the draft from the store.
+  void removeDraft(PathRef File);
+
+  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> asVFS() const;
+
+private:
+  struct DraftAndTime {
+    Draft D;
+    std::time_t MTime;
+  };
+  mutable std::mutex Mutex;
+  llvm::StringMap<DraftAndTime> Drafts;
+};
+
+} // namespace lspserver

--- a/lib/lspserver/include/lspserver/Path.h
+++ b/lib/lspserver/include/lspserver/Path.h
@@ -1,0 +1,45 @@
+//===--- Path.h - Helper typedefs --------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Path.h"
+#include <string>
+
+/// Whether current platform treats paths case insensitively.
+#if defined(_WIN32) || defined(__APPLE__)
+#define CLANGD_PATH_CASE_INSENSITIVE
+#endif
+
+namespace lspserver {
+
+/// A typedef to represent a file path. Used solely for more descriptive
+/// signatures.
+using Path = std::string;
+/// A typedef to represent a ref to file path. Used solely for more descriptive
+/// signatures.
+using PathRef = llvm::StringRef;
+
+// For platforms where paths are case-insensitive (but case-preserving),
+// we need to do case-insensitive comparisons and use lowercase keys.
+// FIXME: Make Path a real class with desired semantics instead.
+std::string maybeCaseFoldPath(PathRef Path);
+bool pathEqual(PathRef, PathRef);
+
+/// Checks if \p Ancestor is a proper ancestor of \p Path. This is just a
+/// smarter lexical prefix match, e.g: foo/bar/baz doesn't start with foo/./bar.
+/// Both \p Ancestor and \p Path must be absolute.
+bool pathStartsWith(
+    PathRef Ancestor, PathRef Path,
+    llvm::sys::path::Style Style = llvm::sys::path::Style::native);
+
+/// Variant of parent_path that operates only on absolute paths.
+/// Unlike parent_path doesn't consider C: a parent of C:\.
+PathRef absoluteParent(PathRef Path);
+} // namespace lspserver

--- a/lib/lspserver/include/lspserver/SourceCode.h
+++ b/lib/lspserver/include/lspserver/SourceCode.h
@@ -1,0 +1,76 @@
+//===--- SourceCode.h - Manipulating source code as strings -----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Various code that examines C++ source code without using heavy AST machinery
+// (and often not even the lexer). To be used sparingly!
+//
+//===----------------------------------------------------------------------===//
+#pragma once
+
+#include "Protocol.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/StringSet.h"
+#include "llvm/Support/Error.h"
+#include <optional>
+#include <string>
+
+namespace lspserver {
+
+template <class Type> class Key {
+public:
+  static_assert(!std::is_reference<Type>::value,
+                "Reference arguments to Key<> are not allowed");
+
+  constexpr Key() = default;
+
+  Key(Key const &) = delete;
+  Key &operator=(Key const &) = delete;
+  Key(Key &&) = delete;
+  Key &operator=(Key &&) = delete;
+};
+
+// This context variable controls the behavior of functions in this file
+// that convert between LSP offsets and native clang byte offsets.
+// If not set, defaults to UTF-16 for backwards-compatibility.
+extern Key<OffsetEncoding> kCurrentOffsetEncoding;
+
+// Counts the number of UTF-16 code units needed to represent a string (LSP
+// specifies string lengths in UTF-16 code units).
+// Use of UTF-16 may be overridden by kCurrentOffsetEncoding.
+size_t lspLength(llvm::StringRef Code);
+
+/// Turn a [line, column] pair into an offset in Code.
+///
+/// If P.character exceeds the line length, returns the offset at end-of-line.
+/// (If !AllowColumnsBeyondLineLength, then returns an error instead).
+/// If the line number is out of range, returns an error.
+///
+/// The returned value is in the range [0, Code.size()].
+llvm::Expected<size_t>
+positionToOffset(llvm::StringRef Code, Position P,
+                 bool AllowColumnsBeyondLineLength = true);
+
+/// Turn an offset in Code into a [line, column] pair.
+/// The offset must be in range [0, Code.size()].
+Position offsetToPosition(llvm::StringRef Code, size_t Offset);
+
+// Expand range `A` to also contain `B`.
+void unionRanges(Range &A, Range B);
+
+/// Apply an incremental update to a text document.
+llvm::Error applyChange(std::string &Contents,
+                        const TextDocumentContentChangeEvent &Change);
+
+/// Collects words from the source code.
+/// Unlike collectIdentifiers:
+/// - also finds text in comments:
+/// - splits text into words
+/// - drops stopwords like "get" and "for"
+llvm::StringSet<> collectWords(llvm::StringRef Content);
+
+} // namespace lspserver

--- a/lib/lspserver/include/lspserver/SourceCode.h
+++ b/lib/lspserver/include/lspserver/SourceCode.h
@@ -23,7 +23,7 @@ namespace lspserver {
 
 template <class Type> class Key {
 public:
-  static_assert(!std::is_reference<Type>::value,
+  static_assert(!std::is_reference_v<Type>,
                 "Reference arguments to Key<> are not allowed");
 
   constexpr Key() = default;

--- a/lib/lspserver/meson.build
+++ b/lib/lspserver/meson.build
@@ -5,6 +5,8 @@ nixd_lsp_server_lib = library('nixd-lspserver'
   , 'src/Logger.cpp'
   , 'src/Protocol.cpp'
   , 'src/URI.cpp'
+  , 'src/DraftStore.cpp'
+  , 'src/SourceCode.cpp'
   ]
 , include_directories: nixd_lsp_server_inc
 , dependencies: [ llvm ]

--- a/lib/lspserver/src/DraftStore.cpp
+++ b/lib/lspserver/src/DraftStore.cpp
@@ -1,0 +1,128 @@
+//===--- DraftStore.cpp - File contents container ---------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "lspserver/DraftStore.h"
+#include "lspserver/Logger.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/Support/VirtualFileSystem.h"
+#include <memory>
+#include <optional>
+
+namespace lspserver {
+
+std::optional<DraftStore::Draft> DraftStore::getDraft(PathRef File) const {
+  std::lock_guard<std::mutex> Lock(Mutex);
+
+  auto It = Drafts.find(File);
+  if (It == Drafts.end())
+    return std::nullopt;
+
+  return It->second.D;
+}
+
+std::vector<Path> DraftStore::getActiveFiles() const {
+  std::lock_guard<std::mutex> Lock(Mutex);
+  std::vector<Path> ResultVector;
+
+  for (auto DraftIt = Drafts.begin(); DraftIt != Drafts.end(); DraftIt++)
+    ResultVector.push_back(std::string(DraftIt->getKey()));
+
+  return ResultVector;
+}
+
+static void increment(std::string &S) {
+  // Ensure there is a numeric suffix.
+  if (S.empty() || !llvm::isDigit(S.back())) {
+    S.push_back('0');
+    return;
+  }
+  // Increment the numeric suffix.
+  auto I = S.rbegin(), E = S.rend();
+  for (;;) {
+    if (I == E || !llvm::isDigit(*I)) {
+      // Reached start of numeric section, it was all 9s.
+      S.insert(I.base(), '1');
+      break;
+    }
+    if (*I != '9') {
+      // Found a digit we can increment, we're done.
+      ++*I;
+      break;
+    }
+    *I = '0'; // and keep incrementing to the left.
+  }
+}
+
+static void updateVersion(DraftStore::Draft &D,
+                          llvm::StringRef SpecifiedVersion) {
+  if (!SpecifiedVersion.empty()) {
+    // We treat versions as opaque, but the protocol says they increase.
+    if (SpecifiedVersion.compare_numeric(D.Version) <= 0)
+      lspserver::log("File version went from {0} to {1}", D.Version,
+                     SpecifiedVersion);
+    D.Version = SpecifiedVersion.str();
+  } else {
+    // Note that if D was newly-created, this will bump D.Version from "" to 1.
+    increment(D.Version);
+  }
+}
+
+std::string DraftStore::addDraft(PathRef File, llvm::StringRef Version,
+                                 llvm::StringRef Contents) {
+  std::lock_guard<std::mutex> Lock(Mutex);
+
+  auto &D = Drafts[File];
+  updateVersion(D.D, Version);
+  std::time(&D.MTime);
+  D.D.Contents = std::make_shared<std::string>(Contents);
+  return D.D.Version;
+}
+
+void DraftStore::removeDraft(PathRef File) {
+  std::lock_guard<std::mutex> Lock(Mutex);
+
+  Drafts.erase(File);
+}
+
+namespace {
+
+/// A read only MemoryBuffer shares ownership of a ref counted string. The
+/// shared string object must not be modified while an owned by this buffer.
+class SharedStringBuffer : public llvm::MemoryBuffer {
+  const std::shared_ptr<const std::string> BufferContents;
+  const std::string Name;
+
+public:
+  BufferKind getBufferKind() const override {
+    return MemoryBuffer::MemoryBuffer_Malloc;
+  }
+
+  llvm::StringRef getBufferIdentifier() const override { return Name; }
+
+  SharedStringBuffer(std::shared_ptr<const std::string> Data,
+                     llvm::StringRef Name)
+      : BufferContents(std::move(Data)), Name(Name) {
+    assert(BufferContents && "Can't create from empty shared_ptr");
+    MemoryBuffer::init(BufferContents->c_str(),
+                       BufferContents->c_str() + BufferContents->size(),
+                       /*RequiresNullTerminator=*/true);
+  }
+};
+} // namespace
+
+llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> DraftStore::asVFS() const {
+  auto MemFS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
+  std::lock_guard<std::mutex> Guard(Mutex);
+  for (const auto &Draft : Drafts)
+    MemFS->addFile(Draft.getKey(), Draft.getValue().MTime,
+                   std::make_unique<SharedStringBuffer>(
+                       Draft.getValue().D.Contents, Draft.getKey()));
+  return MemFS;
+}
+
+} // namespace lspserver

--- a/lib/lspserver/src/SourceCode.cpp
+++ b/lib/lspserver/src/SourceCode.cpp
@@ -1,0 +1,222 @@
+#include "lspserver/SourceCode.h"
+#include "lspserver/Logger.h"
+#include <llvm/Support/Errc.h>
+
+namespace lspserver {
+
+/// TODO: support more encodings (from clangd, using Context)
+static OffsetEncoding lspEncoding() { return OffsetEncoding::UTF16; }
+
+template <typename Callback>
+static bool iterateCodepoints(llvm::StringRef U8, const Callback &CB) {
+  bool LoggedInvalid = false;
+  // A codepoint takes two UTF-16 code unit if it's astral (outside BMP).
+  // Astral codepoints are encoded as 4 bytes in UTF-8, starting with 11110xxx.
+  for (size_t I = 0; I < U8.size();) {
+    unsigned char C = static_cast<unsigned char>(U8[I]);
+    if (LLVM_LIKELY(!(C & 0x80))) { // ASCII character.
+      if (CB(1, 1))
+        return true;
+      ++I;
+      continue;
+    }
+    // This convenient property of UTF-8 holds for all non-ASCII characters.
+    size_t UTF8Length = llvm::countl_one(C);
+    // 0xxx is ASCII, handled above. 10xxx is a trailing byte, invalid here.
+    // 11111xxx is not valid UTF-8 at all, maybe some ISO-8859-*.
+    if (LLVM_UNLIKELY(UTF8Length < 2 || UTF8Length > 4)) {
+      if (!LoggedInvalid) {
+        elog("File has invalid UTF-8 near offset {0}: {1}", I, llvm::toHex(U8));
+        LoggedInvalid = true;
+      }
+      // We can't give a correct result, but avoid returning something wild.
+      // Pretend this is a valid ASCII byte, for lack of better options.
+      // (Too late to get ISO-8859-* right, we've skipped some bytes already).
+      if (CB(1, 1))
+        return true;
+      ++I;
+      continue;
+    }
+    I += UTF8Length; // Skip over all trailing bytes.
+    // A codepoint takes two UTF-16 code unit if it's astral (outside BMP).
+    // Astral codepoints are encoded as 4 bytes in UTF-8 (11110xxx ...)
+    if (CB(UTF8Length, UTF8Length == 4 ? 2 : 1))
+      return true;
+  }
+  return false;
+}
+
+// Like most strings in clangd, the input is UTF-8 encoded.
+size_t lspLength(llvm::StringRef Code) {
+  size_t Count = 0;
+  switch (lspEncoding()) {
+  case OffsetEncoding::UTF8:
+    Count = Code.size();
+    break;
+  case OffsetEncoding::UTF16:
+    iterateCodepoints(Code, [&](int U8Len, int U16Len) {
+      Count += U16Len;
+      return false;
+    });
+    break;
+  case OffsetEncoding::UTF32:
+    iterateCodepoints(Code, [&](int U8Len, int U16Len) {
+      ++Count;
+      return false;
+    });
+    break;
+  case OffsetEncoding::UnsupportedEncoding:
+    llvm_unreachable("unsupported encoding");
+  }
+  return Count;
+}
+
+// Returns the byte offset into the string that is an offset of \p Units in
+// the specified encoding.
+// Conceptually, this converts to the encoding, truncates to CodeUnits,
+// converts back to UTF-8, and returns the length in bytes.
+static size_t measureUnits(llvm::StringRef U8, int Units, OffsetEncoding Enc,
+                           bool &Valid) {
+  Valid = Units >= 0;
+  if (Units <= 0)
+    return 0;
+  size_t Result = 0;
+  switch (Enc) {
+  case OffsetEncoding::UTF8:
+    Result = Units;
+    break;
+  case OffsetEncoding::UTF16:
+    Valid = iterateCodepoints(U8, [&](int U8Len, int U16Len) {
+      Result += U8Len;
+      Units -= U16Len;
+      return Units <= 0;
+    });
+    if (Units < 0) // Offset in the middle of a surrogate pair.
+      Valid = false;
+    break;
+  case OffsetEncoding::UTF32:
+    Valid = iterateCodepoints(U8, [&](int U8Len, int U16Len) {
+      Result += U8Len;
+      Units--;
+      return Units <= 0;
+    });
+    break;
+  case OffsetEncoding::UnsupportedEncoding:
+    llvm_unreachable("unsupported encoding");
+  }
+  // Don't return an out-of-range index if we overran.
+  if (Result > U8.size()) {
+    Valid = false;
+    return U8.size();
+  }
+  return Result;
+}
+
+llvm::Expected<size_t> positionToOffset(llvm::StringRef Code, Position P,
+                                        bool AllowColumnsBeyondLineLength) {
+  if (P.line < 0)
+    return error(llvm::errc::invalid_argument,
+                 "Line value can't be negative ({0})", P.line);
+  if (P.character < 0)
+    return error(llvm::errc::invalid_argument,
+                 "Character value can't be negative ({0})", P.character);
+  size_t StartOfLine = 0;
+  for (int I = 0; I != P.line; ++I) {
+    size_t NextNL = Code.find('\n', StartOfLine);
+    if (NextNL == llvm::StringRef::npos)
+      return error(llvm::errc::invalid_argument,
+                   "Line value is out of range ({0})", P.line);
+    StartOfLine = NextNL + 1;
+  }
+  llvm::StringRef Line =
+      Code.substr(StartOfLine).take_until([](char C) { return C == '\n'; });
+
+  // P.character may be in UTF-16, transcode if necessary.
+  bool Valid;
+  size_t ByteInLine = measureUnits(Line, P.character, lspEncoding(), Valid);
+  if (!Valid && !AllowColumnsBeyondLineLength)
+    return error(llvm::errc::invalid_argument,
+                 "{0} offset {1} is invalid for line {2}", lspEncoding(),
+                 P.character, P.line);
+  return StartOfLine + ByteInLine;
+}
+
+// Workaround for editors that have buggy handling of newlines at end of file.
+//
+// The editor is supposed to expose document contents over LSP as an exact
+// string, with whitespace and newlines well-defined. But internally many
+// editors treat text as an array of lines, and there can be ambiguity over
+// whether the last line ends with a newline or not.
+//
+// This confusion can lead to incorrect edits being sent. Failing to apply them
+// is catastrophic: we're desynced, LSP has no mechanism to get back in sync.
+// We apply a heuristic to avoid this state.
+//
+// If our current view of an N-line file does *not* end in a newline, but the
+// editor refers to the start of the next line (an impossible location), then
+// we silently add a newline to make this valid.
+// We will still validate that the rangeLength is correct, *including* the
+// inferred newline.
+//
+// See https://github.com/neovim/neovim/issues/17085
+static void inferFinalNewline(llvm::Expected<size_t> &Err,
+                              std::string &Contents, const Position &Pos) {
+  if (Err)
+    return;
+  if (!Contents.empty() && Contents.back() == '\n')
+    return;
+  if (Pos.character != 0)
+    return;
+  if (Pos.line != llvm::count(Contents, '\n') + 1)
+    return;
+  log("Editor sent invalid change coordinates, inferring newline at EOF");
+  Contents.push_back('\n');
+  consumeError(Err.takeError());
+  Err = Contents.size();
+}
+
+llvm::Error applyChange(std::string &Contents,
+                        const TextDocumentContentChangeEvent &Change) {
+  if (!Change.range) {
+    Contents = Change.text;
+    return llvm::Error::success();
+  }
+
+  const Position &Start = Change.range->start;
+  llvm::Expected<size_t> StartIndex = positionToOffset(Contents, Start, false);
+  inferFinalNewline(StartIndex, Contents, Start);
+  if (!StartIndex)
+    return StartIndex.takeError();
+
+  const Position &End = Change.range->end;
+  llvm::Expected<size_t> EndIndex = positionToOffset(Contents, End, false);
+  inferFinalNewline(EndIndex, Contents, End);
+  if (!EndIndex)
+    return EndIndex.takeError();
+
+  if (*EndIndex < *StartIndex)
+    return error(llvm::errc::invalid_argument,
+                 "Range's end position ({0}) is before start position ({1})",
+                 End, Start);
+
+  // Since the range length between two LSP positions is dependent on the
+  // contents of the buffer we compute the range length between the start and
+  // end position ourselves and compare it to the range length of the LSP
+  // message to verify the buffers of the client and server are in sync.
+
+  // EndIndex and StartIndex are in bytes, but Change.rangeLength is in UTF-16
+  // code units.
+  ssize_t ComputedRangeLength =
+      lspLength(Contents.substr(*StartIndex, *EndIndex - *StartIndex));
+
+  if (Change.rangeLength && ComputedRangeLength != *Change.rangeLength)
+    return error(llvm::errc::invalid_argument,
+                 "Change's rangeLength ({0}) doesn't match the "
+                 "computed range length ({1}).",
+                 *Change.rangeLength, ComputedRangeLength);
+
+  Contents.replace(*StartIndex, *EndIndex - *StartIndex, Change.text);
+
+  return llvm::Error::success();
+}
+} // namespace lspserver

--- a/lib/nixd/include/nixd/Server.h
+++ b/lib/nixd/include/nixd/Server.h
@@ -1,13 +1,31 @@
 #pragma once
 
 #include "lspserver/Connection.h"
+#include "lspserver/DraftStore.h"
 #include "lspserver/LSPServer.h"
+#include "lspserver/Logger.h"
 #include "lspserver/Protocol.h"
+#include "lspserver/SourceCode.h"
 #include <llvm/Support/JSON.h>
 
 namespace nixd {
 /// The server instance, nix-related language features goes here
 class Server : public lspserver::LSPServer {
+
+  lspserver::DraftStore DraftMgr;
+
+  std::shared_ptr<const std::string> getDraft(lspserver::PathRef File) const;
+
+  void addDocument(lspserver::PathRef File, llvm::StringRef Contents,
+                   llvm::StringRef Version) {
+    DraftMgr.addDraft(File, Version, Contents);
+  }
+
+  void removeDocument(lspserver::PathRef File) { DraftMgr.removeDraft(File); }
+
+  /// LSP defines file versions as numbers that increase.
+  /// treats them as opaque and therefore uses strings instead.
+  static std::string encodeVersion(std::optional<int64_t> LSPVersion);
 
 public:
   Server(std::unique_ptr<lspserver::InboundPort> In,
@@ -15,12 +33,23 @@ public:
       : LSPServer(std::move(In), std::move(Out)) {
     Registry.addMethod("initialize", this, &Server::onInitialize);
     Registry.addNotification("initialized", this, &Server::onInitialized);
+
+    // Text Document Synchronization
+    Registry.addNotification("textDocument/didOpen", this,
+                             &Server::onDocumentDidOpen);
+    Registry.addNotification("textDocument/didChange", this,
+                             &Server::onDocumentDidChange);
   }
 
   void onInitialize(const lspserver::InitializeParams &,
                     lspserver::Callback<llvm::json::Value>);
 
   void onInitialized(const lspserver::InitializedParams &Params){};
+
+  void onDocumentDidOpen(const lspserver::DidOpenTextDocumentParams &Params);
+
+  void
+  onDocumentDidChange(const lspserver::DidChangeTextDocumentParams &Params);
 };
 
 }; // namespace nixd

--- a/lib/nixd/src/Server.cpp
+++ b/lib/nixd/src/Server.cpp
@@ -1,6 +1,8 @@
 #include "nixd/Server.h"
+#include "lspserver/Path.h"
 #include <llvm/Support/Error.h>
 #include <llvm/Support/JSON.h>
+#include <llvm/Support/ScopedPrinter.h>
 
 namespace nixd {
 
@@ -21,6 +23,50 @@ void Server::onInitialize(const lspserver::InitializeParams &InitializeParams,
         llvm::json::Object{{"name", "nixd"}, {"version", "0.0.0"}}},
        {"capabilities", std::move(ServerCaps)}}};
   Reply(std::move(Result));
+}
+
+std::string Server::encodeVersion(std::optional<int64_t> LSPVersion) {
+  return LSPVersion ? llvm::to_string(*LSPVersion) : "";
+}
+
+std::shared_ptr<const std::string>
+Server::getDraft(lspserver::PathRef File) const {
+  auto Draft = DraftMgr.getDraft(File);
+  if (!Draft)
+    return nullptr;
+  return std::move(Draft->Contents);
+}
+
+void Server::onDocumentDidOpen(
+    const lspserver::DidOpenTextDocumentParams &Params) {
+  lspserver::PathRef File = Params.textDocument.uri.file();
+
+  const std::string &Contents = Params.textDocument.text;
+
+  addDocument(File, Contents, encodeVersion(Params.textDocument.version));
+}
+
+void Server::onDocumentDidChange(
+    const lspserver::DidChangeTextDocumentParams &Params) {
+  lspserver::PathRef File = Params.textDocument.uri.file();
+  auto Code = getDraft(File);
+  if (!Code) {
+    lspserver::log("Trying to incrementally change non-added document: {0}",
+                   File);
+    return;
+  }
+  std::string NewCode(*Code);
+  for (const auto &Change : Params.contentChanges) {
+    if (auto Err = applyChange(NewCode, Change)) {
+      // If this fails, we are most likely going to be not in sync anymore
+      // with the client.  It is better to remove the draft and let further
+      // operations fail rather than giving wrong results.
+      removeDocument(File);
+      lspserver::elog("Failed to update {0}: {1}", File, std::move(Err));
+      return;
+    }
+  }
+  addDocument(File, NewCode, encodeVersion(Params.textDocument.version));
 }
 
 } // namespace nixd


### PR DESCRIPTION
Implemented text document sync methods, incrementally sync the textDocument. The implementation is picked from [clangd](https://github.com/llvm/llvm-project/blob/63eb04a3683996db26dbf1534682c5696d93b080/clang-tools-extra/clangd/SourceCode.cpp#L149). 