### PR TITLE
build-system: include nix/config.h in all translation units.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,5 +16,5 @@ jobs:
     - uses: cachix/install-nix-action@v20
       with:
         github_access_token: ${{ secrets.GITHUB_TOKEN }}
-    - run: nix develop --command meson setup build/ --buildtype=release -Dsystem="x86_64-linux"
+    - run: nix develop --command meson setup build/ --buildtype=release
     - run: nix develop --command meson compile -C build

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,8 @@
           shellHook = ''
             export NIX_DEBUG_INFO_DIRS=${nix.debug}/lib/debug
             export NIX_SRC=${nix.src}
+            export NIX_CONFIG_H=${nix.dev}/include/nix/config.h
+            export CXXFLAGS="-include $NIX_CONFIG_H"
           '';
         };
       };

--- a/meson.build
+++ b/meson.build
@@ -3,9 +3,6 @@ project( 'nixd'
        , default_options : ['cpp_std=gnu++20']
        )
 
-
-add_project_arguments('-DSYSTEM="@0@"'.format(get_option('system')), language: 'cpp')
-
 nix_expr = dependency('nix-expr')
 nix_cmd = dependency('nix-cmd')
 nix_store = dependency('nix-store')

--- a/meson.options
+++ b/meson.options
@@ -1,1 +1,0 @@
-option('system', type: 'string', description: 'nix system (platform)')


### PR DESCRIPTION
This is required for nix headers, to make sure that they provide the same declaration as the compiled library.