### PR TITLE
nixd: emove nix ANSI color but not add unit test

### DIFF
--- a/lib/nixd/src/Diagnostic.cpp
+++ b/lib/nixd/src/Diagnostic.cpp
@@ -16,7 +16,7 @@ FUNC(ANSI_BLUE)    \
 FUNC(ANSI_MAGENTA) \
 FUNC(ANSI_CYAN)
 
-static std::string ansiFilter(std::string Msg){
+static std::string stripANSI(std::string Msg){
 #define REMOVE_ANSI_STR_FUNC(ANSI_STR) \
     do { \
         auto Pos = Msg.find(ANSI_STR); \
@@ -38,7 +38,7 @@ std::vector<lspserver::Diagnostic> mkDiagnostics(const nix::Error &PE) {
       ErrPos ? translatePosition(*ErrPos) : lspserver::Position{};
   Ret.push_back(lspserver::Diagnostic{.range = {.start = ErrLoc, .end = ErrLoc},
                                       .severity = /* Error */ 1,
-                                      .message = ansiFilter(PE.info().msg.str())});
+                                      .message = stripANSI(PE.info().msg.str())});
   return Ret;
 }
 

--- a/lib/nixd/src/Diagnostic.cpp
+++ b/lib/nixd/src/Diagnostic.cpp
@@ -2,27 +2,30 @@
 
 #include "lspserver/Protocol.h"
 
-using std::string;
-#define __REMOVED_ANSI_STR__(_) \
-_("\e[0m") \
-_("\e[1m") \
-_("\e[2m") \
-_("\e[3m") \
-_("\e[31;1m") \
-_("\e[32;1m") \
-_("\e[35;1m") \
-_("\e[34;1m") \
-_("\e[35;1m") \
-_("\e[36;1m") \
+#include <nix/ansicolor.hh>
+
+#define FOREACH_ANSI_COLOR(FUNC) \
+FUNC(ANSI_NORMAL)  \
+FUNC(ANSI_BOLD)    \
+FUNC(ANSI_FAINT)   \
+FUNC(ANSI_ITALIC)  \
+FUNC(ANSI_RED)     \
+FUNC(ANSI_GREEN)   \
+FUNC(ANSI_WARNING) \
+FUNC(ANSI_BLUE)    \
+FUNC(ANSI_MAGENTA) \
+FUNC(ANSI_CYAN)
 
 static std::string ansiFilter(std::string Msg){
-    #define __REMOVE_ANSI_STR_CODE__(ansi_str) \
+#define REMOVE_ANSI_STR_FUNC(ANSI_STR) \
     do { \
-        auto Pos = Msg.find(ansi_str); \
-        if (Pos==string::npos) break; \
-        Msg.erase(Pos, std::strlen(ansi_str)); \
-    } while(1);
-    __REMOVED_ANSI_STR__(__REMOVE_ANSI_STR_CODE__)
+        auto Pos = Msg.find(ANSI_STR); \
+        if (Pos == std::string::npos)  \
+            break; \
+        Msg.erase(Pos, std::strlen(ANSI_STR)); \
+    } while(true);
+    FOREACH_ANSI_COLOR(REMOVE_ANSI_STR_FUNC)
+#undef REMOVE_ANSI_STR_FUNC
     return Msg;
 }
 

--- a/lib/nixd/src/Diagnostic.cpp
+++ b/lib/nixd/src/Diagnostic.cpp
@@ -2,6 +2,30 @@
 
 #include "lspserver/Protocol.h"
 
+using std::string;
+#define __REMOVED_ANSI_STR__(_) \
+_("\e[0m") \
+_("\e[1m") \
+_("\e[2m") \
+_("\e[3m") \
+_("\e[31;1m") \
+_("\e[32;1m") \
+_("\e[35;1m") \
+_("\e[34;1m") \
+_("\e[35;1m") \
+_("\e[36;1m") \
+
+static std::string ansiFilter(std::string Msg){
+    #define __REMOVE_ANSI_STR_CODE__(ansi_str) \
+    do { \
+        auto Pos = Msg.find(ansi_str); \
+        if (Pos==string::npos) break; \
+        Msg.erase(Pos, std::strlen(ansi_str)); \
+    } while(1);
+    __REMOVED_ANSI_STR__(__REMOVE_ANSI_STR_CODE__)
+    return Msg;
+}
+
 namespace nixd {
 
 std::vector<lspserver::Diagnostic> mkDiagnostics(const nix::Error &PE) {
@@ -11,7 +35,7 @@ std::vector<lspserver::Diagnostic> mkDiagnostics(const nix::Error &PE) {
       ErrPos ? translatePosition(*ErrPos) : lspserver::Position{};
   Ret.push_back(lspserver::Diagnostic{.range = {.start = ErrLoc, .end = ErrLoc},
                                       .severity = /* Error */ 1,
-                                      .message = PE.info().msg.str()});
+                                      .message = ansiFilter(PE.info().msg.str())});
   return Ret;
 }
 

--- a/lib/nixd/src/Server.cpp
+++ b/lib/nixd/src/Server.cpp
@@ -11,6 +11,10 @@
 
 #include <nix/eval.hh>
 #include <nix/store-api.hh>
+
+#include <filesystem>
+#include <sys/stat.h>
+namespace fs = std::filesystem;
 namespace nixd {
 
 void Server::onInitialize(const lspserver::InitializeParams &InitializeParams,
@@ -85,8 +89,10 @@ void Server::publishStandaloneDiagnostic(lspserver::URIForFile Uri,
   auto NixStore = nix::openStore();
   auto NixState = std::make_unique<nix::EvalState>(nix::Strings{}, NixStore);
   try {
+    fs::path Path = Uri.file().str();
     auto *E =
-        NixState->parseExprFromString(std::move(Content), Uri.file().str());
+        // NixState->parseExprFromString(std::move(Content), Uri.file().str());
+        NixState->parseExprFromString(std::move(Content), Path.remove_filename());
     nix::Value V;
     NixState->eval(E, V);
   } catch (const nix::Error &PE) {

--- a/lib/nixd/src/Server.cpp
+++ b/lib/nixd/src/Server.cpp
@@ -13,7 +13,6 @@
 #include <nix/store-api.hh>
 
 #include <filesystem>
-#include <sys/stat.h>
 namespace fs = std::filesystem;
 namespace nixd {
 
@@ -90,9 +89,8 @@ void Server::publishStandaloneDiagnostic(lspserver::URIForFile Uri,
   auto NixState = std::make_unique<nix::EvalState>(nix::Strings{}, NixStore);
   try {
     fs::path Path = Uri.file().str();
-    auto *E =
-        // NixState->parseExprFromString(std::move(Content), Uri.file().str());
-        NixState->parseExprFromString(std::move(Content), Path.remove_filename());
+    auto *E = NixState->parseExprFromString(std::move(Content),
+                                            Path.remove_filename());
     nix::Value V;
     NixState->eval(E, V);
   } catch (const nix::Error &PE) {

--- a/lib/nixd/test/server.cpp
+++ b/lib/nixd/test/server.cpp
@@ -1,7 +1,6 @@
 #include "nixd/Server.h"
 #include "lspserver/Protocol.h"
 
-#include <cstdio>
 #include <gtest/gtest.h>
 
 #include <llvm/ADT/StringRef.h>

--- a/lib/nixd/test/server.cpp
+++ b/lib/nixd/test/server.cpp
@@ -92,8 +92,7 @@ TEST(Server, DiagnosticSemaUndefineVariable) {
   llvm::StringRef SRO = S.getBuffer();
   std::cout << SRO.str() << "\n";
   ASSERT_TRUE(SRO.contains("undefined variable"));
-  // TODO: Strip ANSI colors here, or report upstream
-  //   ASSERT_TRUE(SRO.contains(R"("whatEverUndefined)"));
+  ASSERT_TRUE(SRO.contains("whatEverUndefined"));
   ASSERT_TRUE(SRO.starts_with("Content-Length:"));
 }
 


### PR DESCRIPTION
`ASSERT_TRUE(SRO.contains(R"("whatEverUndefined)"));` can not pass not because ansi but the redundant `"`, so I remove the comment.

the reason why I not add unit test is that I can not find ANSI code in the output of `SRO.str()` and `Diagnostics[0].message`

Fixes: #10