### PR TITLE
nixd: callback expressions support

### DIFF
--- a/lib/nixd/include/nixd/CallbackExpr.h
+++ b/lib/nixd/include/nixd/CallbackExpr.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "Expr.h"
+#include "eval.hh"
+#include <memory>
+
+namespace nixd {
+
+using ExprCallback =
+    std::function<void(const nix::Expr *, const nix::EvalState &,
+                       const nix::Env &, const nix::Value &)>;
+
+/// Holds AST Nodes.
+class CallbackASTContext {
+  std::vector<std::unique_ptr<nix::Expr>> Nodes;
+
+public:
+  template <class T> T *addNode(std::unique_ptr<T> Node) {
+    Nodes.push_back(std::move(Node));
+    return dynamic_cast<T *>(Nodes.back().get());
+  }
+};
+
+// Nix expression subclass, that will call a readonly callback for analysis.
+#define NIX_EXPR(EXPR)                                                         \
+  struct Callback##EXPR : nix::EXPR {                                          \
+    ExprCallback ECB;                                                          \
+    Callback##EXPR(nix::EXPR E) : nix::EXPR(E) {}                              \
+    Callback##EXPR(nix::EXPR E, ExprCallback ECB) : nix::EXPR(E), ECB(ECB) {}  \
+    static Callback##EXPR *create(CallbackASTContext &Cxt, const nix::EXPR &E, \
+                                  ExprCallback ECB);                           \
+    void eval(nix::EvalState &State, nix::Env &Env, nix::Value &V);            \
+  };
+#include "NixASTNodes.inc"
+#undef NIX_EXPR
+
+/// Evaluate the "Expr", and associate the AST with values.
+class ValueTree {};
+
+nix::Expr *rewriteCallback(CallbackASTContext &Cxt, ExprCallback ECB,
+                           const nix::Expr *Root);
+
+} // namespace nixd

--- a/lib/nixd/meson.build
+++ b/lib/nixd/meson.build
@@ -2,6 +2,7 @@ nixd_server_inc = include_directories('include')
 nixd_server_lib = library('nixd-lsp'
 , [ 'src/Server.cpp'
   , 'src/Diagnostic.cpp'
+  , 'src/CallbackExpr.cpp'
   ]
 , include_directories: nixd_server_inc
 , dependencies: [ llvm

--- a/lib/nixd/src/CallbackExpr.cpp
+++ b/lib/nixd/src/CallbackExpr.cpp
@@ -1,0 +1,46 @@
+#include "nixd/CallbackExpr.h"
+#include "nixd/Expr.h"
+#include "nixexpr.hh"
+#include <memory>
+
+namespace nixd {
+
+#define NIX_EXPR(EXPR)                                                         \
+  Callback##EXPR *Callback##EXPR::create(                                      \
+      CallbackASTContext &Cxt, const nix::EXPR &E, ExprCallback ECB) {         \
+                                                                               \
+    return Cxt.addNode<Callback##EXPR>(                                        \
+        std::make_unique<Callback##EXPR>(E, ECB));                             \
+  }
+#include "nixd/NixASTNodes.inc"
+#undef NIX_EXPR
+
+nix::Expr *rewriteCallback(CallbackASTContext &Cxt, ExprCallback ECB,
+                           const nix::Expr *Root) {
+#define TRY_TO_TRAVERSE(CHILD)                                                 \
+  do {                                                                         \
+    CHILD = dynamic_cast<std::remove_reference<decltype(CHILD)>::type>(        \
+        rewriteCallback(Cxt, ECB, CHILD));                                     \
+  } while (false)
+
+#define DEF_TRAVERSE_TYPE(TYPE, CODE)                                          \
+  if (const auto *E = dynamic_cast<const nix::TYPE *>(Root)) {                 \
+    auto *T = Callback##TYPE::create(Cxt, *E, ECB);                            \
+    { CODE; }                                                                  \
+    return T;                                                                  \
+  }
+#include "nixd/NixASTTraverse.inc"
+  return nullptr;
+#undef TRY_TO_TRAVERSE
+#undef DEF_TRAVERSE_TYPE
+}
+#define NIX_EXPR(EXPR)                                                         \
+  void Callback##EXPR::eval(nix::EvalState &State, nix::Env &Env,              \
+                            nix::Value &V) {                                   \
+    nix::EXPR::eval(State, Env, V);                                            \
+    ECB(this, State, Env, V);                                                  \
+  }
+#include "nixd/NixASTNodes.inc"
+#undef NIX_EXPR
+
+} // namespace nixd

--- a/lib/nixd/test/expr.cpp
+++ b/lib/nixd/test/expr.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include "nixd/CallbackExpr.h"
 #include "nixd/Expr.h"
 #include "nixutil.h"
 
@@ -89,6 +90,59 @@ rec {
 #define NIX_EXPR(EXPR) ASSERT_TRUE(Visitor.Visited##EXPR);
 #include "nixd/NixASTNodes.inc"
 #undef NIX_EXPR
+}
+
+TEST(Expr, CallbackRewrite) {
+  // Verify that all nodes are converted to our types
+  struct ASTDump : nixd::RecursiveASTVisitor<ASTDump>{
+
+#define NIX_EXPR(EXPR)                                                         \
+  bool visit##EXPR(const nix::EXPR *E) {                                       \
+    assert(dynamic_cast<const nixd::Callback##EXPR *>(E) &&                    \
+           "Must be a callback?");                                             \
+    return true;                                                               \
+  }
+#include "nixd/NixASTNodes.inc"
+#undef NIX_EXPR
+                   } A;
+
+  static const char *NixSrc = R"(
+let
+  x = 1;
+in
+rec {
+  integerAnd = 1 && 0;
+  floatAdd = 1.5 + 2.0;
+  ifElse = if 1 then 1 else 0;
+  update = { } // { };
+  opEq = 1 == 2;
+  opNEq = 1 != 2;
+  opImpl = 1 -> 2;
+  opNot = ! false;
+  opOr = 1 || 2;
+  lambda = { }: { };
+  someAttrSet = { a = 1; };
+  hasAttr = someAttrSet ? "a";
+  string = "someString";
+  listConcat = [ 1 2 ] ++ [ 3 4 ];
+  concat = "a" + "b";
+  path = ./.;
+  exprDiv = 5 / 3;
+  exprPos = __curPos;
+  exprAssert = assert true ; "some message";
+  select = someAttrSet.a;
+  exprWith = with someAttrSet; [ ];
+}
+  )";
+  InitNix I;
+  auto S = I.getDummyState();
+  auto ASTContext = std::make_unique<CallbackASTContext>();
+  auto *E = rewriteCallback(
+      *ASTContext,
+      [](const nix::Expr *, const nix::EvalState &, const nix::Env &,
+         const nix::Value &) {},
+      S->parseExprFromString(NixSrc, "/"));
+  A.traverseExpr(E);
 }
 
 } // namespace nixd


### PR DESCRIPTION
This allow us rewritting AST nodes with injected "Callback" on evaluating. Rewritting pattern are generated by macros (with a lot of magic).