### PR TITLE
tools: add `nix-ast-dump`

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -26,6 +26,13 @@ nixd = executable('nixd', ['tools/nixd/nixd.cpp']
                 ] + nix_all
 )
 
+nix_ast_dump = executable('nix-ast-dump', ['tools/nix-ast-dump/nix-ast-dump.cpp']
+, dependencies: [ boost
+                , nixd_server
+                ] + nix_all
+)
+
+
 lit = find_program('lit')
 
 regression_env = environment()
@@ -34,3 +41,4 @@ regression_env.append('PATH', meson.current_build_dir())
 regression_env.set('MESON_BUILD_ROOT', meson.current_build_dir())
 
 test('regression/nixd', lit, env: regression_env, args: [ '../tools/nixd/test' ] )
+test('regression/nix-ast-dump', lit, env: regression_env, args: [ '../tools/nix-ast-dump/test' ], depends: [ nix_ast_dump ])

--- a/tools/nix-ast-dump/nix-ast-dump.cpp
+++ b/tools/nix-ast-dump/nix-ast-dump.cpp
@@ -1,0 +1,58 @@
+#include "nixd/Expr.h"
+
+#include <nix/eval.hh>
+#include <nix/nixexpr.hh>
+#include <nix/shared.hh>
+#include <nix/store-api.hh>
+
+#include <iostream>
+#include <memory>
+
+class InitNix {
+public:
+  InitNix() {
+    nix::initNix();
+    nix::initGC();
+  }
+  std::unique_ptr<nix::EvalState> getDummyState() {
+    return std::make_unique<nix::EvalState>(nix::Strings{},
+                                            nix::openStore("dummy://"));
+  }
+};
+
+struct ASTDump : nixd::RecursiveASTVisitor<ASTDump> {
+
+  int Depth = 0;
+  std::unique_ptr<nix::EvalState> State;
+
+  bool traverseExpr(const nix::Expr *E) {
+    Depth++;
+    if (!nixd::RecursiveASTVisitor<ASTDump>::traverseExpr(E))
+      return false;
+    Depth--;
+    return true;
+  }
+
+#define NIX_EXPR(EXPR)                                                         \
+  bool visit##EXPR(const nix::EXPR *E) {                                       \
+    for (int i = 0; i < Depth; i++) {                                          \
+      std::cout << " ";                                                        \
+    }                                                                          \
+    std::cout << #EXPR << ": ";                                                \
+    E->show(State->symbols, std::cout);                                        \
+    std::cout << "\n";                                                         \
+    return true;                                                               \
+  }
+#include "nixd/NixASTNodes.inc"
+#undef NIX_EXPR
+};
+
+int main(int argc, char *argv[]) {
+  InitNix I;
+  auto State = I.getDummyState();
+  const auto *E = State->parseExprFromFile(argv[1]);
+  ASTDump A;
+  A.State = std::move(State);
+  A.traverseExpr(E);
+  return 0;
+}

--- a/tools/nix-ast-dump/test/all-grammar.nix
+++ b/tools/nix-ast-dump/test/all-grammar.nix
@@ -1,0 +1,109 @@
+# RUN: nix-ast-dump %s | FileCheck %s
+
+# CHECK: ExprLet: (let x = 1; in rec { concat = ("a" + "b"); exprAssert = assert true; "some message"; exprDiv = (__div 5 3); exprPos = __curPos; exprWith = (with someAttrSet; [ ]); floatAdd = (1.5 + 2); hasAttr = ((someAttrSet) ? a); ifElse = (if 1 then 1 else 0); integerAnd = (1 && 0); lambda = ({  }: { }); listConcat = ([ (1) (2) ] ++ [ (3) (4) ]); opEq = (1 == 2); opImpl = (1 -> 2); opNEq = (1 != 2); opNot = (! false); opOr = (1 || 2); path = {{.*}}; select = (someAttrSet).a; someAttrSet = { a = 1; }; string = "someString"; update = ({ } // { }); })
+let
+  # CHECK-NEXT:   ExprAttrs: { x = 1; }
+  # CHECK-NEXT: ExprInt: 1
+  x = 1;
+in
+# CHECK-NEXT: ExprAttrs: rec { concat = ("a" + "b"); exprAssert = assert true; "some message"; exprDiv = (__div 5 3); exprPos = __curPos; exprWith = (with someAttrSet; [ ]); floatAdd = (1.5 + 2); hasAttr = ((someAttrSet) ? a); ifElse = (if 1 then 1 else 0); integerAnd = (1 && 0); lambda = ({  }: { }); listConcat = ([ (1) (2) ] ++ [ (3) (4) ]); opEq = (1 == 2); opImpl = (1 -> 2); opNEq = (1 != 2); opNot = (! false); opOr = (1 || 2); path = {{.*}}; select = (someAttrSet).a; someAttrSet = { a = 1; }; string = "someString"; update = ({ } // { }); }
+rec {
+  # CHECK-NEXT: ExprPath: {{.*}}
+  path = ./.;
+  # CHECK-NEXT: ExprOpHasAttr: ((someAttrSet) ? a)
+  # CHECK-NEXT:   ExprVar: someAttrSet
+  hasAttr = someAttrSet ? "a";
+
+  # CHECK-NEXT: ExprAttrs: { a = 1; }
+  # CHECK-NEXT:     ExprInt: 1
+  someAttrSet = { a = 1; };
+
+  # CHECK-NEXT:    ExprOpAnd: (1 && 0)
+  # CHECK-NEXT:     ExprInt: 1
+  # CHECK-NEXT:     ExprInt: 0
+  integerAnd = 1 && 0;
+
+  # CHECK-NEXT:    ExprConcatStrings: (1.5 + 2)
+  # CHECK-NEXT:     ExprFloat: 1.5
+  # CHECK-NEXT:     ExprFloat: 2
+  floatAdd = 1.5 + 2.0;
+
+  # CHECK-NEXT:    ExprIf: (if 1 then 1 else 0)
+  # CHECK-NEXT:     ExprInt: 1
+  # CHECK-NEXT:     ExprInt: 1
+  # CHECK-NEXT:     ExprInt: 0
+  ifElse = if 1 then 1 else 0;
+
+  # CHECK-NEXT:    ExprOpUpdate: ({ } // { })
+  # CHECK-NEXT:     ExprAttrs: { }
+  # CHECK-NEXT:     ExprAttrs: { }
+  update = { } // { };
+
+  # CHECK-NEXT:    ExprOpEq: (1 == 2)
+  # CHECK-NEXT:     ExprInt: 1
+  # CHECK-NEXT:     ExprInt: 2
+  opEq = 1 == 2;
+
+  # CHECK-NEXT:    ExprOpNEq: (1 != 2)
+  # CHECK-NEXT:     ExprInt: 1
+  # CHECK-NEXT:     ExprInt: 2
+  opNEq = 1 != 2;
+
+  # CHECK-NEXT:    ExprOpImpl: (1 -> 2)
+  # CHECK-NEXT:     ExprInt: 1
+  # CHECK-NEXT:     ExprInt: 2
+  opImpl = 1 -> 2;
+
+  # CHECK-NEXT:    ExprOpNot: (! false)
+  # CHECK-NEXT:     ExprVar: false
+  opNot = ! false;
+
+  # CHECK-NEXT:    ExprOpOr: (1 || 2)
+  # CHECK-NEXT:     ExprInt: 1
+  # CHECK-NEXT:     ExprInt: 2
+  opOr = 1 || 2;
+
+  # CHECK-NEXT:    ExprLambda: ({  }: { })
+  # CHECK-NEXT:     ExprAttrs: { }
+  lambda = {}: { };
+
+  # CHECK-NEXT:    ExprString: "someString"
+  string = "someString";
+
+  # CHECK-NEXT:    ExprOpConcatLists: ([ (1) (2) ] ++ [ (3) (4) ])
+  # CHECK-NEXT:     ExprList: [ (1) (2) ]
+  # CHECK-NEXT:      ExprInt: 1
+  # CHECK-NEXT:      ExprInt: 2
+  # CHECK-NEXT:     ExprList: [ (3) (4) ]
+  # CHECK-NEXT:      ExprInt: 3
+  # CHECK-NEXT:      ExprInt: 4
+  listConcat = [ 1 2 ] ++ [ 3 4 ];
+
+  # CHECK-NEXT:    ExprConcatStrings: ("a" + "b")
+  # CHECK-NEXT:     ExprString: "a"
+  # CHECK-NEXT:     ExprString: "b"
+  concat = "a" + "b";
+
+  # CHECK-NEXT:    ExprCall: (__div 5 3)
+  # CHECK-NEXT:     ExprInt: 5
+  # CHECK-NEXT:     ExprInt: 3
+  # CHECK-NEXT:     ExprVar: __div
+  exprDiv = 5 / 3;
+
+  # CHECK-NEXT:    ExprPos: __curPos
+  exprPos = __curPos;
+
+  # CHECK-NEXT:    ExprAssert: assert true; "some message"
+  # CHECK-NEXT:     ExprVar: true
+  # CHECK-NEXT:     ExprString: "some message"
+  exprAssert = assert true ; "some message";
+
+  # CHECK-NEXT:    ExprSelect: (someAttrSet).a
+  # CHECK-NEXT:     ExprVar: someAttrSet
+  select = someAttrSet.a;
+
+  # CHECK-NEXT:    ExprWith: (with someAttrSet; [ ])
+  # CHECK-NEXT:     ExprVar: someAttrSet
+  # CHECK-NEXT:     ExprList: [ ]
+  exprWith = with someAttrSet; [ ];
+}

--- a/tools/nix-ast-dump/test/lit.cfg.py
+++ b/tools/nix-ast-dump/test/lit.cfg.py
@@ -1,0 +1,20 @@
+import lit
+import os
+
+config.name = "nixd"
+
+config.suffixes = ['.nix']
+
+# testFormat: The test format to use to interpret tests.
+config.test_format = lit.formats.ShTest()
+
+test_root = os.path.dirname(__file__)
+
+build_dir = os.getenv('MESON_BUILD_ROOT', default = '/dev/null')
+
+
+# test_source_root: The root path where tests are located.
+config.test_source_root = test_root
+
+# test_exec_root: The root path where tests should be run.
+config.test_exec_root = build_dir


### PR DESCRIPTION
also add an ast dump utility, produces indented output:

```console
[user@system]$ build/nix-ast-dump ~flakes/shell.nix
 ExprLambda: ({ pkgs ? (let lock = (((builtins).fromJSON ((builtins).readFile ~flakes/flake.lock))).nodes.nixpkgs.locked; nixpkgs = (fetchTarball { sha256 = (lock).narHash; url = ("https://github.com/nixos/nixpkgs/archive/" + (lock).rev + ".tar.gz"); }); in (import nixpkgs { overlays = [ ]; })), ... }: ((pkgs).mkShell { NIX_CONFIG = "extra-experimental-features = nix-command flakes repl-flake"; nativeBuildInputs = (with pkgs; [ (nix) (home-manager) (git) (sops) (gnupg) (age) ]); }))
  ExprLet: (let lock = (((builtins).fromJSON ((builtins).readFile ~flakes/flake.lock))).nodes.nixpkgs.locked; nixpkgs = (fetchTarball { sha256 = (lock).narHash; url = ("https://github.com/nixos/nixpkgs/archive/" + (lock).rev + ".tar.gz"); }); in (import nixpkgs { overlays = [ ]; }))
   ExprAttrs: { lock = (((builtins).fromJSON ((builtins).readFile ~flakes/flake.lock))).nodes.nixpkgs.locked; nixpkgs = (fetchTarball { sha256 = (lock).narHash; url = ("https://github.com/nixos/nixpkgs/archive/" + (lock).rev + ".tar.gz"); }); }
    ExprSelect: (((builtins).fromJSON ((builtins).readFile ~flakes/flake.lock))).nodes.nixpkgs.locked
     ExprCall: ((builtins).fromJSON ((builtins).readFile ~flakes/flake.lock))
      ExprCall: ((builtins).readFile ~flakes/flake.lock)
       ExprPath: ~flakes/flake.lock
       ExprSelect: (builtins).readFile
        ExprVar: builtins
      ExprSelect: (builtins).fromJSON
       ExprVar: builtins
    ExprCall: (fetchTarball { sha256 = (lock).narHash; url = ("https://github.com/nixos/nixpkgs/archive/" + (lock).rev + ".tar.gz"); })
     ExprAttrs: { sha256 = (lock).narHash; url = ("https://github.com/nixos/nixpkgs/archive/" + (lock).rev + ".tar.gz"); }
      ExprConcatStrings: ("https://github.com/nixos/nixpkgs/archive/" + (lock).rev + ".tar.gz")
       ExprString: "https://github.com/nixos/nixpkgs/archive/"
       ExprSelect: (lock).rev
        ExprVar: lock
       ExprString: ".tar.gz"
      ExprSelect: (lock).narHash
       ExprVar: lock
     ExprVar: fetchTarball
   ExprCall: (import nixpkgs { overlays = [ ]; })
    ExprVar: nixpkgs
    ExprAttrs: { overlays = [ ]; }
     ExprList: [ ]
    ExprVar: import
  ExprCall: ((pkgs).mkShell { NIX_CONFIG = "extra-experimental-features = nix-command flakes repl-flake"; nativeBuildInputs = (with pkgs; [ (nix) (home-manager) (git) (sops) (gnupg) (age) ]); })
   ExprAttrs: { NIX_CONFIG = "extra-experimental-features = nix-command flakes repl-flake"; nativeBuildInputs = (with pkgs; [ (nix) (home-manager) (git) (sops) (gnupg) (age) ]); }
    ExprString: "extra-experimental-features = nix-command flakes repl-flake"
    ExprWith: (with pkgs; [ (nix) (home-manager) (git) (sops) (gnupg) (age) ])
     ExprVar: pkgs
     ExprList: [ (nix) (home-manager) (git) (sops) (gnupg) (age) ]
      ExprVar: nix
      ExprVar: home-manager
      ExprVar: git
      ExprVar: sops
      ExprVar: gnupg
      ExprVar: age
   ExprSelect: (pkgs).mkShell
    ExprVar: pkgs
```

```nix
# Shell for bootstrapping flake-enabled nix and other tooling
{ pkgs ? # If pkgs is not defined, instanciate nixpkgs from locked commit
  let
    lock = (builtins.fromJSON (builtins.readFile ./flake.lock)).nodes.nixpkgs.locked;
    nixpkgs = fetchTarball {
      url = "https://github.com/nixos/nixpkgs/archive/${lock.rev}.tar.gz";
      sha256 = lock.narHash;
    };
  in
  import nixpkgs { overlays = [ ]; }
, ...
}: pkgs.mkShell {
  NIX_CONFIG = "extra-experimental-features = nix-command flakes repl-flake";
  nativeBuildInputs = with pkgs; [
    nix
    home-manager
    git

    sops
    gnupg
    age
  ];
}
```