### PR TITLE
nixd/eval: add EvalDraftStore

### DIFF
--- a/lib/nixd/include/nixd/EvalDraftStore.h
+++ b/lib/nixd/include/nixd/EvalDraftStore.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "nixd/AST.h"
+
+#include "lspserver/DraftStore.h"
+#include "nixd/CallbackExpr.h"
+
+#include <exception>
+#include <llvm/ADT/FunctionExtras.h>
+#include <map>
+#include <mutex>
+#include <variant>
+
+namespace nixd {
+
+class EvalDraftStore : public lspserver::DraftStore {
+
+public:
+  struct EvaluationResult {
+    nix::ref<nix::EvalState> State;
+    std::map<std::string, nix::ref<EvalAST>> EvalASTForest;
+    EvaluationResult(nix::ref<nix::EvalState> State,
+                     std::map<std::string, nix::ref<EvalAST>> EvalASTForest)
+        : State(State), EvalASTForest(std::move(EvalASTForest)) {}
+  };
+
+private:
+  /// Cached evaluation result
+  std::mutex Mutex;
+  std::shared_ptr<EvaluationResult> PreviousResult;
+
+public:
+  void withEvaluation(
+      boost::asio::thread_pool &Pool, const nix::Strings &CommandLine,
+      const std::string &Installable,
+      llvm::unique_function<
+          void(std::variant<std::exception *, nix::ref<EvaluationResult>>)>
+          Finish);
+  std::string addDraft(lspserver::PathRef File, llvm::StringRef Version,
+                       llvm::StringRef Contents) {
+    {
+      std::lock_guard<std::mutex> Guard(Mutex);
+      PreviousResult = nullptr;
+    }
+    return lspserver::DraftStore::addDraft(File, Version, Contents);
+  }
+};
+} // namespace nixd

--- a/lib/nixd/include/nixd/EvalDraftStore.h
+++ b/lib/nixd/include/nixd/EvalDraftStore.h
@@ -1,12 +1,13 @@
 #pragma once
 
 #include "nixd/AST.h"
-
-#include "lspserver/DraftStore.h"
 #include "nixd/CallbackExpr.h"
 
-#include <exception>
+#include "lspserver/DraftStore.h"
+
 #include <llvm/ADT/FunctionExtras.h>
+
+#include <exception>
 #include <map>
 #include <mutex>
 #include <variant>

--- a/lib/nixd/include/nixd/EvalDraftStore.h
+++ b/lib/nixd/include/nixd/EvalDraftStore.h
@@ -29,6 +29,7 @@ private:
   /// Cached evaluation result
   std::mutex Mutex;
   std::shared_ptr<EvaluationResult> PreviousResult;
+  bool IsOutdated = true;
 
 public:
   void withEvaluation(
@@ -36,12 +37,13 @@ public:
       const std::string &Installable,
       llvm::unique_function<
           void(std::variant<std::exception *, nix::ref<EvaluationResult>>)>
-          Finish);
+          Finish,
+      bool AcceptOutdated = true);
   std::string addDraft(lspserver::PathRef File, llvm::StringRef Version,
                        llvm::StringRef Contents) {
     {
       std::lock_guard<std::mutex> Guard(Mutex);
-      PreviousResult = nullptr;
+      IsOutdated = true;
     }
     return lspserver::DraftStore::addDraft(File, Version, Contents);
   }

--- a/lib/nixd/meson.build
+++ b/lib/nixd/meson.build
@@ -3,6 +3,7 @@ nixd_server_lib = library('nixd-lsp'
 , [ 'src/AST.cpp'
   , 'src/CallbackExpr.cpp'
   , 'src/Diagnostic.cpp'
+  , 'src/EvalDraftStore.cpp'
   , 'src/Server.cpp'
   ]
 , include_directories: nixd_server_inc
@@ -17,6 +18,7 @@ nixd_server= declare_dependency( link_with: nixd_server_lib
 test_server = executable('test-server'
 , [ 'test/ast.cpp'
   , 'test/diagnostic.cpp'
+  , 'test/evalDraftStore.cpp'
   , 'test/expr.cpp'
   , 'test/server.cpp'
   ]

--- a/lib/nixd/src/EvalDraftStore.cpp
+++ b/lib/nixd/src/EvalDraftStore.cpp
@@ -43,6 +43,7 @@ void EvalDraftStore::withEvaluation(
       // TODO: should we canoicalize 'basePath'?
       auto FileAST = State->parseExprFromString(DraftContents, ActiveFile);
       Forest.insert({ActiveFile, nix::make_ref<EvalAST>(FileAST)});
+      Forest.at(ActiveFile)->preparePositionLookup(*State);
       Forest.at(ActiveFile)->injectAST(*State, ActiveFile);
     }
 

--- a/lib/nixd/src/EvalDraftStore.cpp
+++ b/lib/nixd/src/EvalDraftStore.cpp
@@ -1,0 +1,71 @@
+#include "nixd/EvalDraftStore.h"
+
+#include <nix/command-installable-value.hh>
+#include <nix/eval.hh>
+#include <nix/installable-value.hh>
+#include <nix/nixexpr.hh>
+
+#include <mutex>
+
+namespace nixd {
+
+void EvalDraftStore::withEvaluation(
+    boost::asio::thread_pool &Pool, const nix::Strings &CommandLine,
+    const std::string &Installable,
+    llvm::unique_function<
+        void(std::variant<std::exception *, nix::ref<EvaluationResult>>)>
+        Finish) {
+  {
+    std::lock_guard<std::mutex> Guard(Mutex);
+    if (PreviousResult != nullptr) {
+      Finish(nix::ref(PreviousResult));
+      return;
+    }
+  }
+
+  class MyCmd : public nix::InstallableValueCommand {
+    void run(nix::ref<nix::Store>, nix::ref<nix::InstallableValue>) override {}
+  } Cmd;
+
+  Cmd.parseCmdline(CommandLine);
+
+  nix::ref<nix::EvalState> State = Cmd.getEvalState();
+
+  auto Job = [=, Finish = std::move(Finish), this]() mutable {
+    // First, parsing all active files and rewrite their AST
+    decltype(EvaluationResult::EvalASTForest) Forest;
+
+    auto ActiveFiles = getActiveFiles();
+    for (const auto &ActiveFile : ActiveFiles) {
+      // Safely unwrap optional because they are stored active files.
+      auto DraftContents = *getDraft(ActiveFile).value().Contents;
+
+      // TODO: should we canoicalize 'basePath'?
+      auto FileAST = State->parseExprFromString(DraftContents, ActiveFile);
+      Forest.insert({ActiveFile, nix::make_ref<EvalAST>(FileAST)});
+      Forest.at(ActiveFile)->injectAST(*State, ActiveFile);
+    }
+
+    // Evaluation goes.
+    try {
+      // Installable parsing must do AFTER ast injection.
+      auto IValue = nix::InstallableValue::require(
+          Cmd.parseInstallable(Cmd.getStore(), Installable));
+      IValue->toValue(*State);
+      auto EvalResult = nix::make_ref<EvaluationResult>(State, Forest);
+      Finish(EvalResult);
+      {
+        std::lock_guard<std::mutex> Guard(Mutex);
+        PreviousResult = EvalResult;
+      }
+      return;
+    } catch (std::exception *E) {
+      Finish(E);
+      return;
+    }
+  };
+
+  boost::asio::post(Pool, std::move(Job));
+}
+
+} // namespace nixd

--- a/lib/nixd/test/evalDraftStore.cpp
+++ b/lib/nixd/test/evalDraftStore.cpp
@@ -1,0 +1,54 @@
+#include <gtest/gtest.h>
+
+#include "nixd/EvalDraftStore.h"
+
+#include <nix/command-installable-value.hh>
+#include <nix/installable-value.hh>
+
+#include <memory>
+
+namespace nixd {
+
+TEST(EvalDraftStore, Evaluation) {
+  auto EDS = std::make_unique<EvalDraftStore>();
+
+  boost::asio::thread_pool Pool;
+
+  std::string VirtualTestPath = "/virtual-path-for-testing.nix";
+
+  EDS->addDraft(VirtualTestPath, "0", R"(
+    let x = 1; in x
+  )");
+
+  EDS->withEvaluation(
+      Pool, {"--file", VirtualTestPath}, "",
+      [=](std::variant<std::exception *,
+                       nix::ref<EvalDraftStore::EvaluationResult>>
+              EvalResult) {
+        nix::ref<EvalDraftStore::EvaluationResult> Result =
+            std::get<1>(EvalResult);
+
+        auto Forest = Result->EvalASTForest;
+        auto FooAST = Forest.at(VirtualTestPath);
+        ASSERT_TRUE(FooAST->getValue(FooAST->root()).isTrivial());
+      });
+  Pool.join();
+  EDS->addDraft(VirtualTestPath, "", R"(
+    let x = 2; in x
+  )");
+  EDS->withEvaluation(
+      Pool, {"--file", VirtualTestPath}, "",
+      [=](std::variant<std::exception *,
+                       nix::ref<EvalDraftStore::EvaluationResult>>
+              EvalResult) {
+        nix::ref<EvalDraftStore::EvaluationResult> Result =
+            std::get<1>(EvalResult);
+
+        auto Forest = Result->EvalASTForest;
+        auto FooAST = Forest.at(VirtualTestPath);
+        ASSERT_EQ(FooAST->getValue(FooAST->root()).integer, 2);
+      });
+  Pool.join();
+}
+
+} // namespace nixd

--- a/lib/nixd/test/evalDraftStore.cpp
+++ b/lib/nixd/test/evalDraftStore.cpp
@@ -51,4 +51,32 @@ TEST(EvalDraftStore, Evaluation) {
   Pool.join();
 }
 
+TEST(EvalDraftStore, SetupLookup) {
+  auto EDS = std::make_unique<EvalDraftStore>();
+
+  boost::asio::thread_pool Pool;
+
+  std::string VirtualTestPath = "/virtual-path-for-testing.nix";
+
+  EDS->addDraft(VirtualTestPath, "0", R"(
+    { x = 1; }
+  )");
+
+  EDS->withEvaluation(
+      Pool, {"--file", VirtualTestPath}, "",
+      [=](std::variant<std::exception *,
+                       nix::ref<EvalDraftStore::EvaluationResult>>
+              EvalResult) {
+        nix::ref<EvalDraftStore::EvaluationResult> Result =
+            std::get<1>(EvalResult);
+
+        auto Forest = Result->EvalASTForest;
+        auto FooAST = Forest.at(VirtualTestPath);
+
+        /// Ensure that 'lookupPosition' can be used
+        ASSERT_EQ(FooAST->lookupPosition({0, 0}), FooAST->root());
+      });
+  Pool.join();
+}
+
 } // namespace nixd


### PR DESCRIPTION
Class for virtual workspace evaluation & injection. LSP clients should `addDraft` in this store, and call `withEvaluation`, write logics in the callback.