### PR TITLE
nixd/regression: fixed arrow direction

### DIFF
--- a/tools/nixd/test/basic-diagnostic.md
+++ b/tools/nixd/test/basic-diagnostic.md
@@ -1,6 +1,6 @@
 # RUN: nixd --lit-test < %s | FileCheck %s
 
---> initialize(0)
+<-- initialize(0)
 
 ```json
 {

--- a/tools/nixd/test/initialize.md
+++ b/tools/nixd/test/initialize.md
@@ -2,7 +2,7 @@
 
 Check basic handshake with the server, i.e. "initialize"
 
---> initialize(0)
+<-- initialize(0)
 
 ```json
 {

--- a/tools/nixd/test/workspace-configuration-no-client-cap.md
+++ b/tools/nixd/test/workspace-configuration-no-client-cap.md
@@ -1,7 +1,7 @@
 # RUN: nixd --lit-test < %s | FileCheck %s
 
 
---> initialize(0)
+<-- initialize(0)
 
 ```json
 {

--- a/tools/nixd/test/workspace-configuration.md
+++ b/tools/nixd/test/workspace-configuration.md
@@ -1,7 +1,7 @@
 # RUN: nixd --lit-test < %s | FileCheck %s
 
 
---> initialize(0)
+<-- initialize(0)
 
 ```json
 {


### PR DESCRIPTION
Fixes: #32 

Fixed a mistake where the arrow was not facing the same direction as the other arrows in the rest of the file.